### PR TITLE
wcwidth 0.2.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.5" %}
+{% set version = "0.2.6" %}
 
 package:
   name: wcwidth
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/w/wcwidth/wcwidth-{{ version }}.tar.gz
-  sha256: c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83
+  sha256: a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0
 
 build:
   number: 0


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 575a0bb..3fdd52a 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2.5" %}
+{% set version = "0.2.6" %}
 
 package:
   name: wcwidth
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/w/wcwidth/wcwidth-{{ version }}.tar.gz
-  sha256: c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83
+  sha256: a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0
 
 build:
   number: 0

```

**Jira ticket:** []() (-)

**The upstream data:**

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.2.6
 * Release on PyPi:
    * version: 0.2.6
    * date: 2023-01-15T04:07:25
* [PyPi history](https://pypi.org/project/wcwidth/#history)
 * Popularity: 
    * 3 months downloads: 1851032.0
    * All time:  15080769 downloads -  wcwidth  0.2.6  Measures number of Terminal column cells of wide-character codes.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/jquast/wcwidth/tree/0.2.6 exists
2. - [ ] The upstream url error:
    https://github.com/jquast/wcwidth
    
3. - [ ] Check the pinnings
4. - [ ] Changelog url error:
    https://github.com/jquast/wcwidth/tree/0.2.6
    200
5. - [ ] Additional research
    https://github.com/jquast/wcwidth/issues
    
6. - [ ] `dev_url` error:
    https://github.com/jquast/wcwidth
    
7. - [ ] `doc_url` error:
    
    
8. - [ ] Verify that the `build_number` is correct
9. - [ ] Verify if the package needs `setuptools`
    
10. - [ ] Verify if the package needs `wheel`
    
11. - [x] `pip` in test
12. - [ ] Verify the test section
13. - [ ] Verify if the package is `architecture specific`
14. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
15.  - [x] license_file: LICENSE is present

16. - [ ] License family is NOT present
    
17. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |
</details>

**Check dependency issues:**

<details>
../aggregate/wcwidth-feedstock/recipe/meta.yaml
Dependencies: ['pip', 'python']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 19**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/wcwidth-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/wcwidth-feedstock/tree/0.2.6)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/wcwidth)
* [Diff between upstream and feature branch](https://github.com/conda-forge/wcwidth-feedstock/compare/main...AnacondaRecipes:0.2.6)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/wcwidth-feedstock/compare/master...AnacondaRecipes:0.2.6)
* [The last merged PRs](https://github.com/AnacondaRecipes/wcwidth-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 0.2.6 git@github.com:AnacondaRecipes/wcwidth-feedstock.git
```
